### PR TITLE
Update ccf-2d-reference-library.html

### DIFF
--- a/pages/ccf-2d-reference-library.html
+++ b/pages/ccf-2d-reference-library.html
@@ -410,7 +410,7 @@
                         </ul>
 			
 			<h4 class="mt-5">2D Reference Functional Tissue Unit (FTU) Library Objects</h4>
-			<p><a href="https://github.com/hubmapconsortium/ccf-releases/tree/main/v1.2/2d-ftu" title="HuBMAP 2D Reference Functional Tissue Unit (FTU) Library Objects download" target="_blank">Download v1.0 FTUs</a> in .svg format.<br>
+			<p><a href="https://github.com/hubmapconsortium/ccf-releases/tree/main/v1.2/2d-ftu" title="HuBMAP 2D Reference Functional Tissue Unit (FTU) Library Objects download" target="_blank">Download v1.0 FTUs</a> in SVG format.<br>
 
 				<a Download v1.0 crosswalk information<a href="https://doi.org/10.48539/HBM984.MZSG.873" title="Download file"> ASCT-B to 2D FTU mapping v1.0</a> in CSV format.<br/>
 			<p>	

--- a/pages/ccf-2d-reference-library.html
+++ b/pages/ccf-2d-reference-library.html
@@ -408,8 +408,13 @@
                         <ul>
                             <li><a href="https://drive.google.com/file/d/1KoJCEGMTbpX-LOLNoAZhQgSWNYCPTh41/view" title="go to SOP" target="_blank">Style Guide: HuBMAP 2D Functional Tissue Unit (FTU) Illustrations</a></li>
                         </ul>
+			
+			<h4 class="mt-5">2D Reference Functional Tissue Unit (FTU) Library Objects</h4>
+			<p><a href="https://github.com/hubmapconsortium/ccf-releases/tree/main/v1.2/2d-ftu" title="HuBMAP 2D Reference Functional Tissue Unit (FTU) Library Objects download" target="_blank">Download v1.0 FTUs</a> in .svg format.<br>
 
-                        <h4>Term of use</h4>
+				<a Download v1.0 crosswalk information<a href="https://doi.org/10.48539/HBM984.MZSG.873" title="Download file"> ASCT-B to 2D FTU mapping v1.0</a> in CSV format.<br/>
+			<p>	
+                        <h4>Terms of use</h4>
                         <p>
                             HuBMAP data are supplied with no warranties, expressed or implied, including without limitation, any warranty of merchantability or fitness for a particular purpose or non-infringement. No warranty with respect to the HuBMAP infrastructure is provided, including without limitation, any uptime warranty. The Parties make no representations that the use of the data will not infringe any patent or proprietary rights of third parties.
                         </p>


### PR DESCRIPTION
-Added section to direct CCF portal users to 2D FTU github area to download all files in similar manner to 3D models: 
https://github.com/hubmapconsortium/ccf-releases/tree/main/v1.2/2d-ftu
-Added section to download ASCT+B to 2D FTU crosswalk table as per 3D models page.
-Update "Term of Use" to "Terms of Use"