### PR TITLE
Update ccf-2d-reference-library.html

### DIFF
--- a/pages/ccf-2d-reference-library.html
+++ b/pages/ccf-2d-reference-library.html
@@ -426,7 +426,7 @@
                         <h4>Citation</h4>
                         <p>
                         If you use the 2D data files in v1.2 release, please cite this effort as follows: <br>
-                       Bajema, R., Bidanta, S., Quardokus, E., Herr II, B. W., Börner, K. 2022. <i><a href="https://hubmapconsortium.github.io/ccf/pages/ccf-2d-reference-library.html/">HuBMAP CCF 2D Reference Object Library</a></i>. Accessed on May 6, 2022.
+                       Bajema, R., Bidanta, S., Quardokus, E., Herr II, B. W., Börner, K. 2022. <i><a href="https://hubmapconsortium.github.io/ccf/pages/ccf-2d-reference-library.html">HuBMAP CCF 2D Reference Object Library</a></i>. Accessed on May 6, 2022.
 
                        
 


### PR DESCRIPTION
Remove / at the end of url for https://hubmapconsortium.github.io/ccf/pages/ccf-2d-reference-library.html ; it was giving a 404 not found