### PR TITLE
update zenodo sop link

### DIFF
--- a/pages/omap.html
+++ b/pages/omap.html
@@ -118,7 +118,7 @@
                         <h4>Standard Operating Procedure (SOP)
                         </h4>
                         <ul>
-                            <li>SOP: Construction of Organ Mapping Antibody Panels for Multiplexed Antibody-Based Imaging of Human Tissues <a href="https://doi.org/10.5281/zenodo.5749882" title="go to SOP" target="_blank">https://doi.org/10.5281/zenodo.5749883</a></li>
+                            <li>SOP: Construction of Organ Mapping Antibody Panels for Multiplexed Antibody-Based Imaging of Human Tissues <a href="https://doi.org/10.5281/zenodo.5749882" title="go to SOP" target="_blank">https://doi.org/10.5281/zenodo.5749882.</a></li>
                             
                         </ul>
 			</p>	


### PR DESCRIPTION
only 1 of the 2 areas in html were updated---added correct cite all versions https://doi.org/10.5281/zenodo.5749882 so we won't have to constantly update this; this will always show the most current, but allow you to see other versions too.